### PR TITLE
Add KYC/ID Verification page and link from business page

### DIFF
--- a/src/app/business/kyc/page.tsx
+++ b/src/app/business/kyc/page.tsx
@@ -1,0 +1,28 @@
+import SiteShell from "@/components/SiteShell";
+
+export const metadata = {
+  title: "KYC/ID Verification — ScamAI",
+  description: "Detect forged IDs and deepfakes during onboarding with ScaMai.",
+};
+
+export default function KycPage() {
+  return (
+    <SiteShell>
+      <section className="relative rounded-2xl bg-white/5 p-6 md:p-10 backdrop-blur-sm overflow-hidden">
+        <div
+          className="absolute inset-0 -z-10 opacity-60 bg-cover bg-center"
+          style={{ backgroundImage: "url('/kyc.webp')" }}
+          aria-hidden
+        />
+        <h1 className="text-3xl md:text-4xl font-bold tracking-tight">KYC/ID Verification</h1>
+        <p className="mt-3 text-white/80 max-w-2xl">
+          Verify user identities securely. Detect document forgeries, face swaps
+          onboarding to prevent account fraud.
+        </p>
+
+     
+      </section>
+    </SiteShell>
+  );
+}
+

--- a/src/app/business/page.tsx
+++ b/src/app/business/page.tsx
@@ -4,6 +4,7 @@ export const metadata = {
 };
 
 import SiteShell from "@/components/SiteShell";
+import Link from "next/link";
 
 export default function BusinessPage() {
   return (
@@ -83,6 +84,11 @@ export default function BusinessPage() {
             <h2 className="mt-4 text-lg font-semibold tracking-tight">{card.title}</h2>
             <p className="mt-2 text-sm text-white/80">{card.desc}</p>
             <span className="absolute right-4 bottom-4 text-xs text-white/70">{card.tag}</span>
+            {card.title === "KYC/ID Verification" && (
+              <Link href="/business/kyc" aria-label="Open KYC/ID Verification" className="absolute inset-0">
+                {/* overlay link */}
+              </Link>
+            )}
           </article>
         ))}
       </section>


### PR DESCRIPTION
Introduces a new KYC/ID Verification page under /business/kyc with relevant metadata and content. Updates the business page to include a navigational link to the new KYC page when the corresponding card is displayed.